### PR TITLE
Release the resources allocated by the ConvertThreadToFiber function

### DIFF
--- a/Scheduler/Include/Platform/Windows/MTFiberDefault.h
+++ b/Scheduler/Include/Platform/Windows/MTFiberDefault.h
@@ -71,6 +71,10 @@ namespace MT
 				{
 					::DeleteFiber(fiber);
 				}
+				else 
+				{
+					::ConvertFiberToThread();
+				}
 				fiber = nullptr;
 			}
 		}

--- a/Scheduler/Include/Platform/Windows/MicroWindows.h
+++ b/Scheduler/Include/Platform/Windows/MicroWindows.h
@@ -297,6 +297,7 @@ MW_WINBASEAPI MW_BOOL MW_WINAPI VirtualFree( void* lpAddress, size_t dwSize, MW_
 
 MW_WINBASEAPI void MW_WINAPI DeleteFiber( void* lpFiber );
 MW_WINBASEAPI void* MW_WINAPI ConvertThreadToFiberEx( void* lpParameter, MW_DWORD dwFlags );
+MW_WINBASEAPI MW_BOOL MW_WINAPI ConvertFiberToThread();
 MW_WINBASEAPI void* MW_WINAPI CreateFiber( size_t dwStackSize, TFiberStartFunc lpStartAddress, void* lpParameter );
 MW_WINBASEAPI void MW_WINAPI SwitchToFiber( void* lpFiber );
 MW_WINBASEAPI MW_BOOL MW_WINAPI IsThreadAFiber();


### PR DESCRIPTION
Found in https://github.com/SergeyMakeev/TaskScheduler/issues/4 by @ChemiaAion 

> The function releases the resources allocated by the ConvertThreadToFiber function. After calling this function, you cannot call any of the fiber functions from the thread.

See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-convertfibertothread for details.