### PR TITLE
Fix some MSVC and PVS-Studio static analyzer issues

### DIFF
--- a/Scheduler/Include/MTTaskDesc.h
+++ b/Scheduler/Include/MTTaskDesc.h
@@ -68,6 +68,7 @@ namespace MT
 				, poolDestroyFunc(nullptr)
 				, userData(nullptr)
 				, stackRequirements(MT::StackRequirements::INVALID)
+				, priority(MT::TaskPriority::INVALID)
 			{
 #ifdef MT_INSTRUMENTED_BUILD
 				debugID = nullptr;
@@ -93,6 +94,7 @@ namespace MT
 				, poolDestroyFunc(_poolDestroyFunc)
 				, userData(_userData)
 				, stackRequirements(_stackRequirements)
+				, priority(MT::TaskPriority::INVALID)
 			{
 #ifdef MT_INSTRUMENTED_BUILD
 				debugID = nullptr;

--- a/Scheduler/Include/Platform/Windows/MTEventUser.h
+++ b/Scheduler/Include/Platform/Windows/MTEventUser.h
@@ -66,11 +66,11 @@ namespace MT
 		{
 		}
 
-		Event(EventReset::Type resetType, bool initialState)
+		Event(EventReset::Type resetType_, bool initialState)
 			: numOfWaitingThreads(0)
 			, isInitialized(false)
 		{
-			Create(resetType, initialState);
+			Create(resetType_, initialState);
 		}
 
 		~Event()
@@ -82,10 +82,10 @@ namespace MT
 			}
 		}
 
-		void Create(EventReset::Type _resetType, bool initialState)
+		void Create(EventReset::Type resetType_, bool initialState)
 		{
 			MT_ASSERT (!isInitialized, "Event already initialized");
-			resetType = _resetType;
+			resetType = resetType_;
 
 			::InitializeCriticalSectionAndSpinCount( &criticalSection, 16 );
 			::InitializeConditionVariable( &condition );

--- a/Scheduler/Include/Platform/Windows/MTThread.h
+++ b/Scheduler/Include/Platform/Windows/MTThread.h
@@ -163,7 +163,7 @@ namespace MT
 			{
 				cpuCore = MW_MAXIMUM_PROCESSORS;
 			}
-			MT_VERIFY((cpuCore >= 0 && cpuCore < (uint32)GetNumberOfHardwareThreads()) || cpuCore == MW_MAXIMUM_PROCESSORS, "Invalid cpu core specified", cpuCore=MW_MAXIMUM_PROCESSORS);
+			MT_VERIFY((cpuCore < (uint32)GetNumberOfHardwareThreads()) || cpuCore == MW_MAXIMUM_PROCESSORS, "Invalid cpu core specified", cpuCore=MW_MAXIMUM_PROCESSORS);
 			MW_DWORD res = ::SetThreadIdealProcessor(thread, cpuCore);
 			MT_USED_IN_ASSERT(res);
 			MT_ASSERT(res != (MW_DWORD)-1, "SetThreadIdealProcessor failed!");
@@ -231,7 +231,7 @@ namespace MT
 			{
 				cpuCore = MW_MAXIMUM_PROCESSORS;
 			}
-			MT_VERIFY((cpuCore >= 0 && cpuCore < (uint32)GetNumberOfHardwareThreads()) || cpuCore == MW_MAXIMUM_PROCESSORS, "Invalid cpu core specified", cpuCore=MW_MAXIMUM_PROCESSORS);
+			MT_VERIFY((cpuCore < (uint32)GetNumberOfHardwareThreads()) || cpuCore == MW_MAXIMUM_PROCESSORS, "Invalid cpu core specified", cpuCore=MW_MAXIMUM_PROCESSORS);
 			MW_DWORD res = ::SetThreadIdealProcessor( ::GetCurrentThread(), cpuCore);
 			MT_USED_IN_ASSERT(res);
 			MT_ASSERT(res != (MW_DWORD)-1, "SetThreadIdealProcessor failed!");

--- a/Scheduler/Source/MTDefaultAppInterop.cpp
+++ b/Scheduler/Source/MTDefaultAppInterop.cpp
@@ -101,8 +101,8 @@ namespace MT
 		MW_SYSTEM_INFO systemInfo;
 		GetSystemInfo(&systemInfo);
 
-		int pageSize = (int)systemInfo.dwPageSize;
-		int pagesCount = (int)size / pageSize;
+		size_t pageSize = systemInfo.dwPageSize;
+		size_t pagesCount = size / pageSize;
 
 		//need additional page for stack guard
 		if ((size % pageSize) > 0)

--- a/Scheduler/Source/MTFiberContext.cpp
+++ b/Scheduler/Source/MTFiberContext.cpp
@@ -30,6 +30,7 @@ namespace MT
 		, stackRequirements(StackRequirements::INVALID)
 		, childrenFibersCount(0)
 		, parentFiber(nullptr)
+		, fiberIndex(UINT_MAX)
 	{
 		
 	}

--- a/Scheduler/Source/MTScheduler.cpp
+++ b/Scheduler/Source/MTScheduler.cpp
@@ -402,7 +402,7 @@ namespace MT
 
 		bool isTaskStealingDisabled = context.taskScheduler->IsTaskStealingDisabled(0);
 
-		int64 timeOut = GetTimeMicroSeconds() + (waitContext.waitTimeMs * 1000);
+		int64 timeOut = GetTimeMicroSeconds() + ((int64)waitContext.waitTimeMs * 1000);
 
 		SpinWait spinWait;
 		

--- a/premake4.lua
+++ b/premake4.lua
@@ -6,7 +6,7 @@ isPosix = false
 isVisualStudio = false
 isOSX = false
 
-if _ACTION == "vs2002" or _ACTION == "vs2003" or _ACTION == "vs2005" or _ACTION == "vs2008" or _ACTION == "vs2010" then
+if _ACTION == "vs2002" or _ACTION == "vs2003" or _ACTION == "vs2005" or _ACTION == "vs2008" or _ACTION == "vs2010" or _ACTION == "vs2012" then
 	isVisualStudio = true
 end
 
@@ -21,13 +21,17 @@ then
 end
 
 
-	
+
 solution "TaskScheduler"
 
 	language "C++"
 
 	location ( "Build/" .. _ACTION )
+if isVisualStudio then
+	flags {"NoManifest", "ExtraWarnings", "StaticRuntime", "NoMinimalRebuild", "FloatFast" }
+else
 	flags {"NoManifest", "ExtraWarnings", "StaticRuntime", "NoMinimalRebuild", "FloatFast", "EnableSSE2" }
+end
 	optimization_flags = { "OptimizeSpeed" }
 	targetdir("Bin")
 
@@ -39,17 +43,16 @@ if isOSX then
 	defines { "_DARWIN_C_SOURCE=1" }
 end
 
-
 if isVisualStudio then
+	defines { "_ALLOW_RTCc_IN_STL=1" }
 	debugdir ("Bin")
 end
-
 
 	local config_list = {
 		"Release",
 		"Debug",
-                "Instrumented_Release",
-                "Instrumented_Debug"
+		"Instrumented_Release",
+		"Instrumented_Debug"
 	}
 	local platform_list = {
 		"x32",
@@ -81,7 +84,8 @@ configuration "Debug"
 configuration "x32"
 if isVisualStudio then
 -- Compiler Warning (level 4) C4127. Conditional expression is constant
-        buildoptions { "/wd4127"  }
+	buildoptions { "/wd4127"  }
+	flags { "EnableSSE2" }
 else
 	buildoptions { "-std=c++11" }
   if isPosix then
@@ -101,7 +105,7 @@ end
 configuration "x64"
 if isVisualStudio then
 -- Compiler Warning (level 4) C4127. Conditional expression is constant
-        buildoptions { "/wd4127"  }
+	buildoptions { "/wd4127"  }
 else
 	buildoptions { "-std=c++11" }
   if isPosix then
@@ -207,6 +211,5 @@ project "TaskSchedulerTests"
 	if isPosix or isOSX then
 		links { "pthread" }
 	end
-
 
 


### PR DESCRIPTION
* Support vs2012 and set correct defines for STL (vs2012+) and SSE (x86-64 has by default).
* `unsigned` always >= 0.
* Do not truncate `DWORD` or `size_t` to `int`, that can lead to problems for large (> `INT_MAX`) values.
* Doesn't overflow `uint32` in multiplication operation.
* Initialize class members to prevent hard to track bugs with uninitialized storage usage.
* Name args and class members differently to prevent confusion. Also, do not create reserved identifiers (`_XXX`) in client code.

Handy PVS-Studio links: 
Product page: https://www.viva64.com/en/pvs-studio/
How to use for free: https://www.viva64.com/en/b/0600/